### PR TITLE
Fix "Uncaught RangeError: offset is not uint"

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ var CHUNK_NAMES = {
 
 
 function parseFaceListChunk(buf) {
-  var faceCount = buf.readUInt16LE();
+  var faceCount = buf.readUInt16LE(0);
 
   // The face array contains 3 vertex indices + a 2 bytes 
   // bit-field containing various flags (see [1]).
@@ -83,7 +83,7 @@ function parseFaceListChunk(buf) {
 
 
 function parseVertexListChunk(buf) {
-  var vertexCount = buf.readUInt16LE();
+  var vertexCount = buf.readUInt16LE(0);
   var vertices = buf.slice(2);
 
   // The vertice coordinates are returned as a Float32LE buffer 


### PR DESCRIPTION
Hi,

seems like `buffer.readXXX` functions cannot be called without arguments anymore.

This PR adds explicit zero offsets, which avoids `Uncaught RangeError` being thrown.

Regards,
Olivier.
