### PR TITLE
Get access to full tree data

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ var parsed = parse3DS(buf);
     { name: 'a', vertices: [ ... ], faces: [ ... ] },
     { name: 'b', vertices: [ ... ], faces: [ ... ] },
     { name: 'c', vertices: [ ... ], faces: [ ... ] }
+  ],
+  tree: [
+    // Unparsed nodes will have an extra 'data' field
+    { id: 42, length: 42, name: 'abc', children: [ ... ] }
   ]
 }
 */

--- a/README.md
+++ b/README.md
@@ -14,12 +14,21 @@ $ npm install parse-3ds
 Usage
 -----
 
+### parsed = require('parse-3ds')((buf[, options])) ###
+
+Returns the parsed contents of `buf`. `options`, if present, can contain the following keys:
+* `objects`: if `true`, object data will be available. Default is `true`.
+* `tree`: if `true`, the full chunks tree will be available. Default is `false`.
+
+Example
+-------
+
 ```javascript
 var parse3DS = require('parse-3ds');
 var fs = require('fs');
 
 var buf = fs.readFileSync('test.3ds');
-var parsed = parse3DS(buf);
+var parsed = parse3DS(buf, { 'objects':true, 'tree':true });
 
 /*
 { 

--- a/index.js
+++ b/index.js
@@ -222,6 +222,7 @@ module.exports = function(buf) {
   });
 
   return {
-    objects: objects
+    objects: objects,
+    tree: rootChunk
   };
 };

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ var CHUNK_NAMES = {
 
 
 function parseFaceListChunk(buf) {
-  var faceCount = buf.readUInt16LE();
+  var faceCount = buf.readUInt16LE(0);
 
   // The face array contains 3 vertex indices + a 2 bytes 
   // bit-field containing various flags (see [1]).
@@ -83,7 +83,7 @@ function parseFaceListChunk(buf) {
 
 
 function parseVertexListChunk(buf) {
-  var vertexCount = buf.readUInt16LE();
+  var vertexCount = buf.readUInt16LE(0);
   var vertices = buf.slice(2);
 
   // The vertice coordinates are returned as a Float32LE buffer 

--- a/index.js
+++ b/index.js
@@ -148,6 +148,9 @@ function parseChunk(buf, offset) {
     chunk = objectAssign({}, chunk, parsed);
   } else if(NON_LEAF_CHUNKS.indexOf(chunk.id) !== -1) {
     chunk.children = parseChildren(data);
+  } else {
+    // Keep raw data if unparsed node has no children
+    chunk.data = data;
   }
 
   return chunk;


### PR DESCRIPTION
This PR provides access to the full content of the parsed 3DS file, through the following features:
- an extra `tree` attribute points to the root tree,
- raw data of unparsed chunks is kept in a `data` attribute.

This should ease investigation of file contents, especially wrt unknown or partially-parsed chunks.

Compatibility with existing `parse-3ds` dependents should not be broken.

Regards,
Olivier.
